### PR TITLE
fix typo; fix build.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you want to learn about the compiling script, you can read the introduction.
 |-- projects              # Folder of main projects
 ```
 1. `README.md` is the project's description document.
-2. The `build.sh` is a verilator compilation script that greatly simplifies the compilation of vialtor. At the same time, this script can record the user's compilation history to avoid faking. **Note: Modification of this script is forbidden!!!**
+2. The `build.sh` is a verilator compilation script that greatly simplifies the compilation of verilator. At the same time, this script can record the user's compilation history to avoid faking. **Note: Modification of this script is forbidden!!!**
 3. The `myinfo.txt` records the user's personal information, which should be updated in this file first after entering the environment for the first time. The compile script records this information when it records the user's compile history. If personal information is written, the compile script will not work.
 4. The directory `demo`, holds demo file to validate the environment setup.
 5. The directory `doc`,  holds the relevant documentation and some manuals about RISC-V.

--- a/build.sh
+++ b/build.sh
@@ -117,7 +117,7 @@ fi
 BUILD_PATH=$PROJECT_PATH/$BUILD_FOLDER
 BIN_PATH=$ICS_PATH/$PROJECT_FOLDER/$BIN_FOLDER
 
-Get id and name
+# Get id and name
 ID=`sed '/^ID=/!d;s/.*=//' $MYINFO_FILE`
 NAME=`sed '/^Name=/!d;s/.*=//' $MYINFO_FILE`
 if [[ ${#ID} -le 1 ]] || [[ ${#NAME} -le 1 ]]; then

--- a/doc/manual_2.md
+++ b/doc/manual_2.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-The `build.sh` is a verilator compilation script that greatly simplifies the compilation of vialtor. At the same time, this script can record the user's compilation history to avoid faking.
+The `build.sh` is a verilator compilation script that greatly simplifies the compilation of verilator. At the same time, this script can record the user's compilation history to avoid faking.
 
 ## Parameter
 


### PR DESCRIPTION
1. fix two typos in manual
2. The line 120 of build.sh seems missing comment `#`.